### PR TITLE
Add in .gitattributes the files not needed in tarball

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,9 @@
 *.PDF	 diff=astextplain
 *.rtf	 diff=astextplain
 *.RTF	 diff=astextplain
+
+# Avoid sending useless files when downloading tarball from github
+.gitignore export-ignore
+.gitattributes export-ignore
+readme.txt export-ignore
+screenshot-1.png export-ignore


### PR DESCRIPTION
When a tarball is downloaded from https://github.com/webvitalii/iframe/zipball/master
it contains every file, although several are useful only for development
purposes, not for the end user.

github understands the `export-ignore` directive and avoids sending those files,
which hence reduces the footprint of this plugin